### PR TITLE
fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ VERSION=1.2.1
 SNAPSHOT=
 
 PY_DIRS=cjc cjc/ui plugins
-DOCS=doc/manual.html COPYING ChangeLog README TODO
+DOCS=COPYING ChangeLog README TODO
 
 EXTRA_DIST=cjc.in cjc.py doc/manual.xml doc/Makefile
 


### PR DESCRIPTION
[...]
install -d /usr/local/share/doc/cjc
install -m 644 doc/manual.html COPYING ChangeLog README TODO /usr/local/share/doc/cjc
install: cannot stat 'doc/manual.html': No such file or directory
make: *** [Makefile:60: install] Error 1